### PR TITLE
Add proper spacing to panel icons when disabled.

### DIFF
--- a/templates/gs-3.10/gnome-shell.css
+++ b/templates/gs-3.10/gnome-shell.css
@@ -726,7 +726,8 @@ StScrollBar StButton#hhandle:active {
     /*panelicon_true
     panelicon_true*/
     /*panelicon_false
-    width: 0;
+    height: 0;
+    width: 12px;
     panelicon_false*/
     app-icon-bottom-clip: 0;
 }

--- a/templates/gs-3.6/gnome-shell.css
+++ b/templates/gs-3.6/gnome-shell.css
@@ -623,7 +623,8 @@ StScrollBar StButton#hhandle:active {
     /*panelicon_true
     panelicon_true*/
     /*panelicon_false
-    width: 0;
+    height: 0;
+    width: 12px;
     panelicon_false*/
     app-icon-bottom-clip: 0;
 }

--- a/templates/gs-3.8/gnome-shell.css
+++ b/templates/gs-3.8/gnome-shell.css
@@ -673,7 +673,8 @@ StScrollBar StButton#hhandle:active {
     /*panelicon_true
     panelicon_true*/
     /*panelicon_false
-    width: 0;
+    height: 0;
+    width: 12px;
     panelicon_false*/
     app-icon-bottom-clip: 0;
 }


### PR DESCRIPTION
http://puu.sh/55iQr.png

With this added spacing the active application looks like it belongs with no icon rather than looking as if it out of place with and not properly centered.
