### PR TITLE
switched bc with awk - hence removing the bc dep

### DIFF
--- a/elegance-colors
+++ b/elegance-colors
@@ -112,7 +112,7 @@ fi
 get_luma() {
 basecolor="$1"
 get_rgba "$basecolor"
-luma=$(echo "$red * 0.2126 + $green * 0.7152 + $blue * 0.0722" | bc -l)
+luma=$(awk "BEGIN { printf(\"%f\n\", $red * 0.2126 + $green * 0.7152 + $blue * 0.0722 ) }")
 printf ${luma%.*}
 }
 


### PR DESCRIPTION
Instead of using "bc -l" in line 115 I switched it with awk. It was the only occurence of it. bc is a great tool and I have it installed however it is not common. One may save one extra dependency if using awk instead because it is already used a couple of times and therefore already must be installed.
